### PR TITLE
增加docker build action

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,43 @@
+name: Docker Build and Push
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+env:
+  IMAGE_REPOSITORY: aaamoon/copilot-gpt4-service
+
+jobs:
+  docker-release:
+    name: Publish Docker images
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_REPOSITORY }}:latest
+          platforms: |
+            linux/amd64
+            linux/arm64
+            linux/arm/v7
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
添加了一个 GitHub Action，用于定时构建 Docker 镜像。构建的依据文件是项目根目录下的 Dockerfile。

配置的镜像名称为：`aaamoon/copilot-gpt4-service`

Action正常运行之前，Owner 需要在项目的 "Actions secrets and variables" 中添加一下 Repository secrets：

- **DOCKER_USERNAME**：Docker Hub 用户名（应该是：aaamoon 吧？！）
- **DOCKER_PASSWORD**：Docker Hub token。

