### PR TITLE
自定义服务器验证支持、默认路由处理、补充响应数据缺失字段

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,9 +210,9 @@ func main() {
 	router := gin.Default()
 	router.Use(CORSMiddleware())
 	router.POST("/v1/chat/completions", chatCompletions)
-    router.GET("/v1/models", createMockModelsResponse)
-    router.NoRoute(func(c *gin.Context) {
-        c.String(http.StatusMethodNotAllowed, "Method Not Allowed")
-    })
+	router.GET("/v1/models", createMockModelsResponse)
+	router.NoRoute(func(c *gin.Context) {
+		c.String(http.StatusMethodNotAllowed, "Method Not Allowed")
+	})
 	router.Run(":8080")
 }

--- a/main.go
+++ b/main.go
@@ -139,7 +139,17 @@ func mainRequest(c *gin.Context) {
 					return
 				}
 				if n > 0 {
-					c.Writer.Write(body[:n])
+					rlt_body := body[:n]
+
+					// Add the missing fields to the response body
+					if bytes.Contains(rlt_body, []byte(`"choices":`)) && !bytes.Contains(rlt_body, []byte(`"object":`)) {
+						rlt_body = bytes.ReplaceAll(rlt_body, []byte(`"choices":`), []byte(`"object": "chat.completion.chunk", "choices":`))
+					}
+					if bytes.Contains(rlt_body, []byte(`"choices":`)) && !bytes.Contains(rlt_body, []byte(`"model":`)) {
+						rlt_body = bytes.ReplaceAll(rlt_body, []byte(`"choices":`), []byte(`"model": "gpt-4", "choices":`))
+					}
+
+					c.Writer.Write(rlt_body)
 					c.Writer.Flush()
 				}
 				if err == io.EOF {
@@ -157,9 +167,52 @@ func chatCompletions(c *gin.Context) {
 	mainRequest(c)
 }
 
+
+func createMockModel(modelId string) gin.H {
+	return gin.H{
+		"id": modelId,
+		"object": "model",
+		"created": 1677610602,
+		"owned_by": "openai",
+		"permission": []gin.H{
+			{
+				"id": "modelperm-" + genHexStr(12),
+				"object": "model_permission",
+				"created": 1677610602,
+				"allow_create_engine": false,
+				"allow_sampling": true,
+				"allow_logprobs": true,
+				"allow_search_indices": false,
+				"allow_view": true,
+				"allow_fine_tuning": false,
+				"organization": "*",
+				"group": nil,
+				"is_blocking": false,
+			},
+		},
+		"root": modelId,
+		"parent": nil,
+	}
+}
+
+func createMockModelsResponse(c *gin.Context) {
+    c.JSON(http.StatusOK, gin.H{
+        "object": "list",
+        "data": []gin.H{
+			createMockModel("gpt-3.5-turbo"),
+			createMockModel("gpt-4"),
+        },
+    })
+}
+
+
 func main() {
 	router := gin.Default()
 	router.Use(CORSMiddleware())
 	router.POST("/v1/chat/completions", chatCompletions)
+    router.GET("/v1/models", createMockModelsResponse)
+    router.NoRoute(func(c *gin.Context) {
+        c.String(http.StatusMethodNotAllowed, "Method Not Allowed")
+    })
 	router.Run(":8080")
 }


### PR DESCRIPTION
使用过程中，发现的几个问题，调整下：
1. 新增：/v1/models 路由，旨在满足 ChatX App 第三方客户端自定义 Host 验证的需求。目前如：ChatX、OpenCat 验证 Host 都是通过 /v1/models 进行验证。
2. 增加默认路由处理方式为：405 Method Not Allowed。
3. 为流式数据补充缺失字段：object、model。（原生接口中包含这两个字段，但在 Copilot 中缺失，导致 ChatX 客户端无法正确处理流式返回数据。）

目前以上修改在 ChatGPT-Next-Web、ChatX 测试OK。
