### PR TITLE
增加linux和windows平台通过 github-copilot-cli 一键获取token

### DIFF
--- a/shells/get_copilot_token.bat
+++ b/shells/get_copilot_token.bat
@@ -1,0 +1,52 @@
+@echo off
+
+where /q npm
+if %errorlevel% neq 0 (
+    echo Node.js is not installed. Please download it from https://nodejs.org/en/download
+    pause
+    exit /b
+)
+
+where /q github-copilot-cli
+if %errorlevel% neq 0 (
+    echo github-copilot-cli is not installed. Installing...
+    npm i @githubnext/github-copilot-cli -g
+    if %errorlevel% neq 0 (
+        echo Failed to install github-copilot-cli. Please check your npm installation and try again.
+        pause
+        exit /b
+    )
+)
+
+:: Check if token file exists
+if exist %USERPROFILE%\.copilot-cli-access-token (
+    :: View the token
+    type %USERPROFILE%\.copilot-cli-access-token
+    echo.
+
+    :: Ask user if they want to reauthorize
+    set /p reauth="Token exists. Do you want to reauthorize? (Y/N): "
+    if /i "%reauth%" neq "Y" (
+        echo Exiting script...
+        exit /b
+    )
+)
+
+:: Retrieve the token
+github-copilot-cli auth
+if %errorlevel% neq 0 (
+    echo Failed to retrieve GitHub Copilot Token. Please check your internet connection and try again.
+    pause
+    exit /b
+)
+
+:: View the token
+type %USERPROFILE%\.copilot-cli-access-token
+
+if %errorlevel% neq 0 (
+    echo Failed to view the token. Please check the file path and try again.
+    pause
+    exit /b
+)
+
+pause

--- a/shells/get_copilot_token.sh
+++ b/shells/get_copilot_token.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if ! command -v npm &> /dev/null
+then
+    echo "npm is not installed. Please install npm first."
+    exit
+fi
+
+if ! command -v github-copilot-cli &> /dev/null
+then
+    echo "github-copilot-cli is not installed. Installing..."
+    npm i @githubnext/github-copilot-cli -g
+fi
+
+# Retrieve the token
+github-copilot-cli auth
+
+# View the token
+cat ~/.copilot-cli-access-token

--- a/shells/get_copilot_token.sh
+++ b/shells/get_copilot_token.sh
@@ -12,6 +12,17 @@ then
     npm i @githubnext/github-copilot-cli -g
 fi
 
+# Check if the token file exists
+if [ -f ~/.copilot-cli-access-token ]; then
+    echo "Existing token: $(cat ~/.copilot-cli-access-token)"
+    read -p "Do you want to reauthorize? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+        exit 1
+    fi
+fi
+
 # Retrieve the token
 github-copilot-cli auth
 


### PR DESCRIPTION
Linux可以封装为一键命令，如下：

```bash
bash -c "$(curl -fsSL https://raw.githubusercontent.com/aaamoon/copilot-gpt4-service/feat/get_copilot_token/shells/get_copilot_token.sh)"
```

Windows下双击 `get_copilot_token.bat` 脚本。

两个平台获取的逻辑一样。