### PR TITLE
deploy: helm chart deployment configuration and installation doc.

### DIFF
--- a/.chart/copilot-gpt4-service/.helmignore
+++ b/.chart/copilot-gpt4-service/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+/Makefile

--- a/.chart/copilot-gpt4-service/Chart.lock
+++ b/.chart/copilot-gpt4-service/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: chatgpt-next-web
-  repository: https://charts.kii.la
-  version: 0.1.1
-digest: sha256:ea1a7a52f09b492e30db91c2e66bfa25a3db3ab878d7099daeeea94e90f33d5e
-generated: "2024-01-08T01:31:41.186129+08:00"

--- a/.chart/copilot-gpt4-service/Chart.lock
+++ b/.chart/copilot-gpt4-service/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: chatgpt-next-web
+  repository: https://charts.kii.la
+  version: 0.1.1
+digest: sha256:ea1a7a52f09b492e30db91c2e66bfa25a3db3ab878d7099daeeea94e90f33d5e
+generated: "2024-01-08T01:31:41.186129+08:00"

--- a/.chart/copilot-gpt4-service/Chart.yaml
+++ b/.chart/copilot-gpt4-service/Chart.yaml
@@ -2,6 +2,12 @@ apiVersion: v2
 name: copilot-gpt4-service
 description: A Helm chart for Kubernetes
 
+dependencies:
+  - name: chatgpt-next-web
+    repository: https://charts.kii.la
+    version: 0.1.x
+
+
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -15,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/.chart/copilot-gpt4-service/README.md
+++ b/.chart/copilot-gpt4-service/README.md
@@ -7,10 +7,22 @@
 ## 快速安装
 使用`helm`命令安装`HLEM Chart`，命令如下：
 ```bash
-git clone https://github.com/aaamoon/copilot-gpt4-service.git
-# git clone git@github.com:aaamoon/copilot-gpt4-service.git
-cd copilot-gpt4-service/.chart
-helm upgrade copilot-gpt4-service . --namespace copilot-gpt4-service --create-namespace --install  
+helm repo add aaamoon https://charts.kii.la && helm repo update # 源由 github pages 提供
+helm install copilot-gpt4-service aaamoon/copilot-gpt4-service
+
+
+## 与Chat GPT Next Web一起安装
+helm install copilot-gpt4-service aaamoon/copilot-gpt4-service \
+  --set chatgpt-next-web.enabled=true \
+  --set chatgpt-next-web.config.OPENAI_API_KEY=[ your openai api key ] \ # copilot 获取的 token
+  --set chatgpt-next-web.config.CODE=[ backend access code ] \    # next gpt web ui 的访问密码
+  --set chatgpt-next-web.service.type=NodePort \
+  --set chatgpt-next-web.service.nodePort=30080
+```
+
+如需更多配置, 可自行定义 values , 然后使用 -f 指定 values 文件
+```bash
+helm install copilot-gpt4-service aaamoon/copilot-gpt4-service -f values.yaml
 ```
 
 ## Values 字段说明

--- a/.chart/copilot-gpt4-service/README.md
+++ b/.chart/copilot-gpt4-service/README.md
@@ -18,46 +18,54 @@ helm upgrade copilot-gpt4-service . --namespace copilot-gpt4-service --create-na
 下面是对`hlem chart`中Values字段的解释：
 请根据实际需求调整`Values`字段的值，以满足您的部署需求。
 以下是使用Markdown的表格格式输出对默认值进行解释的文档：
+好的，下面是更详细的层级描述和默认值：
 
-| 字段 | 类型 | 默认值 | 解释 |
-| --- | --- | --- | --- |
-| replicaCount | 整数 | 1 | 副本数量，用于指定部署的副本数量。默认为1，表示只部署一个副本。 |
-| image.repository | 字符串 | 空 | 镜像仓库地址，用于指定部署所使用的镜像的仓库地址。请根据实际情况填写正确的镜像仓库地址。 |
-| image.pullPolicy | 字符串 | IfNotPresent | 镜像拉取策略，用于指定镜像拉取的策略。默认为IfNotPresent，表示如果镜像已经存在则不再拉取。 |
-| tag | 字符串 | latest | 镜像标签，用于指定部署所使用的镜像的标签。默认为latest，表示使用最新的镜像标签。 |
-| imagePullSecrets | 列表 | 空 | 镜像拉取的凭证，用于从私有镜像仓库拉取镜像。请根据实际情况填写正确的镜像拉取凭证。 |
-| nameOverride | 字符串 | 空 | 重写名称，用于覆盖生成的名称。默认为空，表示不进行名称重写。 |
-| fullnameOverride | 字符串 | 空 | 完整名称重写，用于覆盖生成的完整名称。默认为空，表示不进行完整名称重写。 |
-| serviceAccount.create | 布尔值 | true | 是否创建ServiceAccount。默认为true，表示创建ServiceAccount。 |
-| serviceAccount.automount | 布尔值 | true | 是否自动挂载ServiceAccount的API凭证。默认为true，表示自动挂载API凭证。 |
-| serviceAccount.annotations | 字典 | 空 | ServiceAccount的注解列表，用于添加额外的元数据。默认为空，表示没有额外的注解。 |
-| serviceAccount.name | 字符串 | 空 | 使用的ServiceAccount的名称。如果未设置且`serviceAccount.create`为true，则使用fullname模板生成名称。 |
-| podAnnotations | 字典 | 空 | Pod的注解列表，用于添加额外的元数据。默认为空，表示没有额外的注解。 |
-| podLabels | 字典 | 空 | Pod的标签列表，用于组织和筛选Pod。默认为空，表示没有额外的标签。 |
-| podSecurityContext | 字典 | 空 | Pod的安全上下文，用于指定Pod的安全策略。默认为空，表示没有额外的安全上下文。 |
-| fsGroup | 整数 | 空 | 文件系统组ID，用于指定Pod中所有容器的文件系统组ID。默认为空，表示不指定文件系统组ID。 |
-| securityContext | 字典 | 空 | 安全上下文，用于指定容器的安全策略。默认为空，表示不指定额外的安全上下文。 |
-| capabilities.drop | 列表 | 空 | 容器的能力列表，用于指定容器所拥有的能力。默认为空，表示不指定额外的能力。 |
-| readOnlyRootFilesystem | 布尔值 | 空 | 是否将根文件系统设置为只读。默认为空，表示不将根文件系统设置为只读。 |
-| runAsNonRoot | 布尔值 | 空 | 是否以非root用户身份运行容器。默认为空，表示以root用户身份运行容器。 |
-| runAsUser | 整数 | 空 | 容器运行的用户ID。默认为空，表示使用默认的用户ID。 |
-| service.type | 字符串 | ClusterIP | 服务的类型，用于指定服务的访问方式。默认为ClusterIP，表示通过集群内部的IP地址访问服务。 |
-| service.port | 整数 | 空 | 服务的端口号，用于指定服务的访问端口。默认为空，表示没有指定端口号。 |
-| ingress.enabled | 布尔值 | 空 | 是否启用Ingress。如果启用，则可以通过Ingress访问服务。 |
-| ingress.className | 字符串 | 空 | Ingress的类名，用于指定Ingress的类。默认为空，表示没有指定类名。 |
-| ingress.annotations | 字典 | 空 | Ingress的注解列表，用于添加额外的元数据。默认为空，表示没有额外的注解。 |
-| ingress.hosts | 列表 | 空 | Ingress的主机列表，用于指定Ingress的访问域名。默认为空，表示没有指定主机。 |
-| ingress.paths | 列表 | 空 | Ingress的路径列表，用于指定Ingress的访问路径。默认为空，表示没有指定路径。 |
-| ingress.pathType | 字符串 | 空 | Ingress的路径类型，用于指定Ingress的路径类型。默认为空，表示没有指定路径类型。 |
-| ingress.tls | 列表 | 空 | Ingress的TLS配置列表，用于指定Ingress的TLS配置。默认为空，表示没有指定TLS配置。 |
-| resources | 字典 | 空 | 资源配置，用于指定容器的资源需求和限制。默认为空，表示没有指定资源配置。 |
-| autoscaling.enabled | 布尔值 | 空 | 是否启用自动扩缩容。如果启用，则可以根据资源利用率自动调整副本数量。 |
-| autoscaling.minReplicas | 整数 | 空 | 自动扩缩容的最小副本数量，用于指定自动扩缩容的下限。 |
-| autoscaling.maxReplicas | 整数 | 空 | 自动扩缩容的最大副本数量，用于指定自动扩缩容的上限。 |
-| autoscaling.targetCPUUtilizationPercentage | 整数 | 空 | 自动扩缩容的目标CPU利用率百分比，用于指定自动扩缩容的目标。 |
-| autoscaling.targetMemoryUtilizationPercentage | 整数 | 空 | 自动扩缩容的目标内存利用率百分比，用于指定自动扩缩容的目标。 |
-| volumes | 列表 | 空 | 附加到输出的Deployment定义的卷列表，用于挂载额外的存储卷。默认为空，表示没有附加的卷。 |
-| volumeMounts | 列表 | 空 | 附加到输出的Deployment定义的卷挂载列表，用于指定存储卷的挂载路径。默认为空，表示没有附加的卷挂载。 |
-| nodeSelector | 字典 | 空 | 节点选择器，用于指定部署所在的节点。默认为空，表示没有指定节点选择器。 |
-| tolerations | 列表 | 空 | 允许的污点列表，用于容忍指定的节点污点。默认为空，表示没有指定允许的污点。 |
-| affinity | 字典 | 空 | 亲和性设置，用于指定部署的亲和性，如与指定的节点亲和等。默认为空，表示没有指定亲和性设置。 |
+| 字段 | 默认值 | 描述                              |
+| --- | --- |---------------------------------|
+| `replicaCount` | 1 | 部署的副本数量                         |
+| `image.repository` | aaamoon/copilot-gpt4-service | 容器镜像的仓库名                        |
+| `image.pullPolicy` | Always | 容器镜像的拉取策略                       |
+| `image.tag` | latest | 容器镜像的标签                         |
+| `config.HOST` | 0.0.0.0 | 应用的主机配置                         |
+| `config.PORT` | 8080 | 应用的端口配置                         |
+| `persistent.cache.enabled` | false | 是否启用缓存                          |
+| `persistent.cache.type` | pvc | 缓存的类型，可以是 pvc 或 hostPath        |
+| `persistent.cache.name` | cache | 缓存的名称                           |
+| `persistent.cache.mountPath` | /var/copilot-gpt4-service/cache.sqlite3 | 缓存的挂载路径                         |
+| `persistent.cache.pvc.storageClassName` | "" | PVC 的存储类，如果为空则使用默认的存储类          |
+| `persistent.cache.pvc.claimName` | copilot-gpt4-service-cache | PVC 的声明名称                       |
+| `persistent.cache.pvc.accessModes` | [ReadWriteOnce] | PVC 的访问模式                       |
+| `persistent.cache.pvc.size` | 1Gi | PVC 的大小                         |
+| `persistent.cache.hostPath.path` | /var/copilot-gpt4-service/cache.sqlite3 | hostPath 的路径                    |
+| `persistent.cache.hostPath.type` | DirectoryOrCreate | hostPath 的类型                    |
+| `imagePullSecrets` | [ ] | 拉取私有镜像所需的密钥                     |
+| `nameOverride` | "" | 用于覆盖默认的 Helm 发布名称               |
+| `fullnameOverride` | "copilot-gpt4-service" | 用于覆盖默认的 Helm 完整发布名称             |
+| `serviceAccount.create` | true | 是否创建服务账户                        |
+| `serviceAccount.automount` | true | 是否自动挂载服务账户的 API 凭证              |
+| `serviceAccount.annotations` | { } | 服务账户的注解                         |
+| `serviceAccount.name` | "" | 服务账户的名称                         |
+| `podAnnotations` | { } | Pod 的注解                         |
+| `podLabels` | { } | Pod 的标签                         |
+| `podSecurityContext` | { } | Pod 的安全上下文                      |
+| `securityContext` | { } | 容器的安全上下文                        |
+| `service.type` | ClusterIP | 服务的类型                           |
+| `service.port` | 8080 | 服务的端口                           |
+| `ingress.enabled` | false | 是否启用 Ingress                    |
+| `ingress.className` | "nginx" | Ingress 的类名                     |
+| `ingress.annotations` | { } | Ingress 的注解                     |
+| `ingress.hosts` | [{host: example.com, paths: [{path: /, pathType: ImplementationSpecific}]}] | Ingress 的主机和路径配置                |
+| `ingress.tls` | [ ] | Ingress 的 TLS 配置                |
+| `resources` | { } | 资源限制和请求的配置                      |
+| `autoscaling.enabled` | false | 是否启用自动扩缩                        |
+| `autoscaling.minReplicas` | 1 | 自动扩缩的最小副本数                      |
+| `autoscaling.maxReplicas` | 100 | 自动扩缩的最大副本数                      |
+| `autoscaling.targetCPUUtilizationPercentage` | 80 | 自动扩缩的 CPU 利用率目标                 |
+| `volumeMounts` | [ ] | 额外的卷挂载配置                        |
+| `nodeSelector` | { } | 节点选择器的配置                        |
+| `tolerations` | [ ] | 容忍度的配置                          |
+| `affinity` | { } | 亲和性的配置                          |
+| `chatgpt-next-web.enabled` | false | 是否启用下一代 ChatGPT web             |
+| `chatgpt-next-web.config.BASE_URL` | http://copilot-gpt4-service:8080 | Next ChatGPT web 的基础 URL         |
+| `chatgpt-next-web.config.OPENAI_API_KEY` | [ your openai api key ] | Next ChatGPT web 的 OpenAI API 密钥 |
+| `chatgpt-next-web.config.CODE` | [ backend access code ] | Next ChatGPT web 的后端访问码         |

--- a/.chart/copilot-gpt4-service/templates/configmap.yaml
+++ b/.chart/copilot-gpt4-service/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "copilot-gpt4-service.fullname" . }}
+  labels:
+    {{- include "copilot-gpt4-service.labels" . | nindent 4 }}
+data:
+{{- range $k,$v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+{{- end }}
+  {{- if .Values.persistent.cache.enabled }}
+  CACHE: "true"
+  CACHE_DIR: {{ .Values.persistent.cache.mountPath | quote }}
+  {{- end }}

--- a/.chart/copilot-gpt4-service/templates/deployment.yaml
+++ b/.chart/copilot-gpt4-service/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "copilot-gpt4-service.fullname" . }}
+                optional: true
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -48,15 +52,29 @@ spec:
             httpGet:
               path: /healthz
               port: http
+          {{- if .Values.persistent.cache.enabled }}
+          volumeMounts:
+            - name: {{ .Values.persistent.cache.name }}
+              mountPath: {{ .Values.persistent.cache.mountPath }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- if .Values.persistent.cache.enabled }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- if eq .Values.persistent.cache.type "pvc" }}
+        - name: {{ .Values.persistent.cache.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistent.cache.pvc.claimName }}
+        {{- else if eq .Values.persistent.cache.type "hostPath" }}
+        - name: {{ .Values.persistent.cache.name }}
+          hostPath:
+            path: {{ .Values.persistent.cache.hostPath.path }}
+            type: {{ .Values.persistent.cache.hostPath.type }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/.chart/copilot-gpt4-service/templates/persistent.yaml
+++ b/.chart/copilot-gpt4-service/templates/persistent.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.persistent.cache.enabled  }}
+{{- if eq .Values.persistent.cache.type "pvc" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.persistent.cache.pvc.claimName }}
+  labels:
+    {{- include "copilot-gpt4-service.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- .Values.persistent.cache.pvc.accessModes | toYaml | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistent.cache.pvc.size | default "1Gi" }}
+  {{- with .Values.persistent.cache.pvc.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end  }}
+{{- end  }}

--- a/.chart/copilot-gpt4-service/values.yaml
+++ b/.chart/copilot-gpt4-service/values.yaml
@@ -6,13 +6,34 @@ replicaCount: 1
 
 image:
   repository: aaamoon/copilot-gpt4-service
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
 
-imagePullSecrets: []
+config:
+  HOST: 0.0.0.0
+  PORT: 8080
+
+
+persistent:
+  cache:
+    enabled: false # true or false
+    type: pvc # pvc or hostPath
+    name: cache
+    mountPath: /var/copilot-gpt4-service/cache.sqlite3
+    pvc: # if type is pvc
+      storageClassName: "" # if empty use default storage class
+      claimName: copilot-gpt4-service-cache
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi
+    hostPath: # if type is hostPath
+      path: /var/copilot-gpt4-service/cache.sqlite3
+      type: DirectoryOrCreate
+
+imagePullSecrets: [ ]
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: "copilot-gpt4-service"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -20,24 +41,24 @@ serviceAccount:
   # Automatically mount a ServiceAccount's API credentials?
   automount: true
   # Annotations to add to the service account
-  annotations: {}
+  annotations: { }
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
-podLabels: {}
+podAnnotations: { }
+podLabels: { }
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext: { }
+# fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext: { }
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 
 service:
   type: ClusterIP
@@ -45,31 +66,28 @@ service:
 
 ingress:
   enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  className: "nginx"
+  annotations: { }
+  #    cert-manager.io/cluster-issuer: letsencrypt-prod
+  #    kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: example.com
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  tls: [ ]
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources: { }
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
 
 autoscaling:
   enabled: false
@@ -78,21 +96,25 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
+volumeMounts: [ ]
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }
+
+chatgpt-next-web:
+  enabled: false
+  config:
+    BASE_URL: http://copilot-gpt4-service:8080 # if you want to use copilot-gpt4-service
+    OPENAI_API_KEY: [ your openai api key ]
+    CODE: [ backend access code ]
+    #  AZURE_URL: https://[your azure api url] # if you want to use azure api
+    #  AZURE_API_VERSION: 2023-08-01-preview # if you want to use azure api
+    #  AZURE_API_KEY: [your azure api key] # if you want to use azure api

--- a/README.md
+++ b/README.md
@@ -69,10 +69,17 @@ git pull && docker compose up -d --build
 支持通过 Kubernetes 部署，具体部署方式如下：
 
 ```shell
-git clone https://github.com/aaamoon/copilot-gpt4-service.git
-# git clone git@github.com:aaamoon/copilot-gpt4-service.git
-cd copilot-gpt4-service/.chart
-helm upgrade copilot-gpt4-service . --namespace copilot-gpt4-service --create-namespace --install  
+helm repo add aaamoon https://charts.kii.la && helm repo update # 源由 github pages 提供
+helm install copilot-gpt4-service aaamoon/copilot-gpt4-service
+
+
+## 与Chat GPT Next Web一起安装
+helm install copilot-gpt4-service aaamoon/copilot-gpt4-service \
+  --set chatgpt-next-web.enabled=true \
+  --set chatgpt-next-web.config.OPENAI_API_KEY=[ your openai api key ] \ # copilot 获取的 token
+  --set chatgpt-next-web.config.CODE=[ backend access code ] \    # next gpt web ui 的访问密码
+  --set chatgpt-next-web.service.type=NodePort \
+  --set chatgpt-next-web.service.nodePort=30080
 ```
 
 ### Cloudflare Worker

--- a/README_EN.md
+++ b/README_EN.md
@@ -69,10 +69,17 @@ git pull && docker compose up -d --build
 Supports deployment through Kubernetes, the specific deployment method is as follows:
 
 ```shell
-git clone https://github.com/aaamoon/copilot-gpt4-service.git
-# git clone git@github.com:aaamoon/copilot-gpt4-service.git
-cd copilot-gpt4-service/.chart
-helm upgrade copilot-gpt4-service . --namespace copilot-gpt4-service --create-namespace --install  
+helm repo add aaamoon https://charts.kii.la && helm repo update # Source by github pages
+helm install copilot-gpt4-service aaamoon/copilot-gpt4-service
+
+
+## Installation with Chat GPT Next Web
+helm install copilot-gpt4-service aaamoon/copilot-gpt4-service \
+  --set chatgpt-next-web.enabled=true \
+  --set chatgpt-next-web.config.OPENAI_API_KEY=[ your openai api key ] \   #Token obtained by copilot
+  --set chatgpt-next-web.config.CODE=[ backend access code ] \    # Access password for next chatgpt web ui
+  --set chatgpt-next-web.service.type=NodePort \
+  --set chatgpt-next-web.service.nodePort=30080
 ```
 
 ### Cloudflare Worker


### PR DESCRIPTION
目前维护了基于 Github Pages 的当前项目的 Chart Repo, 包含两个 Chart. 

- [chatgpt-next-web](https://artifacthub.io/packages/helm/chatgpt-next-web/chatgpt-next-web)
chatgpt next web 的 Chart, 用做当前项目的依赖项目, 实现一键打包部署. 
其实这个应该是上游服务, 应该 ChatGpt Next Web 引入当前项目. 但是反向做也不是不可以. 

- [copilot-gpt4-service](https://artifacthub.io/packages/helm/copilot-gpt4-service/copilot-gpt4-service)
copilot-gpt4-service 的 Chart, 源码同当前提交, 实现了 env 的参数, 以及 cache 的参数引入. 
并且将 chatgpt next web 作为依赖, 默认联动, 无需额外配置.
