### PR TITLE
Fix status code format in log format

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func LoggerHandler() gin.HandlerFunc {
 		c.Next()
 
 		latency := time.Since(t)
-		log.ZLog.Log.Info().Msgf("Response Time: %s\nStatus: %s",
+		log.ZLog.Log.Info().Msgf("Response Time: %s\nStatus: %d",
 			latency.String(), c.Writer.Status())
 		log.ZLog.Log.Debug().Msgf("Response Header:\n%v", c.Writer.Header())
 	}


### PR DESCRIPTION
Before
```
URL: /v1/chat/completions
2024-01-10 18:22:17 INF Response Time: 1.878990798s
Status: %!s(int=200)
```

After fixed
```
URL: /v1/chat/completions
2024-01-10 18:24:44 INF Response Time: 2.681168974s
Status: 200
```