### PR TITLE
feat: allow users to specify Copilot Token when starting the service

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,13 +1,3 @@
-/*
- * @Author: Vincent Young
- * @Date: 2024-01-13 19:10:40
- * @LastEditors: Vincent Young
- * @LastEditTime: 2024-01-13 19:49:26
- * @FilePath: /copilot-gpt4-service/config/config.go
- * @Telegram: https://t.me/missuo
- *
- * Copyright © 2024 by Vincent, All Rights Reserved.
- */
 package config
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,13 @@
+/*
+ * @Author: Vincent Young
+ * @Date: 2024-01-13 19:10:40
+ * @LastEditors: Vincent Young
+ * @LastEditTime: 2024-01-13 19:49:26
+ * @FilePath: /copilot-gpt4-service/config/config.go
+ * @Telegram: https://t.me/missuo
+ *
+ * Copyright © 2024 by Vincent, All Rights Reserved.
+ */
 package config
 
 import (
@@ -9,13 +19,14 @@ import (
 )
 
 type Config struct {
-	Port      string
-	Cache     bool
-	CachePath string
-	Host      string
-	Debug     bool
-	Logging   bool
-	LogLevel  string
+	Port         string
+	Cache        bool
+	CachePath    string
+	Host         string
+	Debug        bool
+	Logging      bool
+	LogLevel     string
+	CopilotToken string
 }
 
 var ConfigInstance *Config = NewConfig()
@@ -30,13 +41,14 @@ func NewConfig() *Config {
 	}
 
 	return &Config{
-		Host:      getEnvOrDefault("HOST", "localhost"),
-		Port:      getEnvOrDefault("PORT", "8080"),
-		Cache:     getEnvOrDefaultBool("CACHE", true),
-		CachePath: getEnvOrDefault("CACHE_PATH", "db/cache.sqlite3"),
-		Debug:     getEnvOrDefaultBool("DEBUG", false),
-		Logging:   getEnvOrDefaultBool("LOGGING", true),
-		LogLevel:  getEnvOrDefault("LOG_LEVEL", "info"),
+		Host:         getEnvOrDefault("HOST", "localhost"),
+		Port:         getEnvOrDefault("PORT", "8080"),
+		Cache:        getEnvOrDefaultBool("CACHE", true),
+		CachePath:    getEnvOrDefault("CACHE_PATH", "db/cache.sqlite3"),
+		Debug:        getEnvOrDefaultBool("DEBUG", false),
+		Logging:      getEnvOrDefaultBool("LOGGING", true),
+		LogLevel:     getEnvOrDefault("LOG_LEVEL", "info"),
+		CopilotToken: getEnvOrDefault("COPILOT_TOKEN", ""),
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: Dockerfile
     environment:
       - HOST=0.0.0.0
+      #- COPILOT_TOKEN=gnu_xxxxx
     ports:
       - 8080:8080
     restart: unless-stopped

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"copilot-gpt4-service/cache"
+	"copilot-gpt4-service/config"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -61,10 +62,14 @@ func GetAuthorizationFromToken(copilotToken string) (string, int, string) {
 
 // Retrieve the GitHub Copilot Plugin Token from the request header.
 func GetAuthorization(c *gin.Context) (string, bool) {
-	copilotToken := strings.TrimPrefix(c.GetHeader("Authorization"), "Bearer ")
-	if copilotToken == "" {
-		return "", false
+	if config.ConfigInstance.CopilotToken == "" {
+		copilotToken := strings.TrimPrefix(c.GetHeader("Authorization"), "Bearer ")
+		if copilotToken == "" {
+			return "", false
+		} else {
+			return copilotToken, true
+		}
 	} else {
-		return copilotToken, true
+		return config.ConfigInstance.CopilotToken, true
 	}
 }


### PR DESCRIPTION
Allow users to fill in the **Copilot Token** in the environment variables or configuration files. When the **Copilot Token** exists, a string can be passed freely during the request.

If the user does not fill in the **Copilot Token** when starting the service, it needs to be carried with each request.