### PR TITLE
fix docker image panic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM golang:latest AS builder
+FROM golang:alpine AS builder
 
 WORKDIR /app
 
 # Duplicate the application code.
 COPY . .
+
+RUN apk update && apk upgrade && apk add build-base
 
 # Construct the application.
 RUN CGO_ENABLED=1 GOOS=linux go build -o copilot-gpt4-service .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY . .
 
 # Construct the application.
-RUN CGO_ENABLED=0 GOOS=linux go build -o copilot-gpt4-service .
+RUN CGO_ENABLED=1 GOOS=linux go build -o copilot-gpt4-service .
 
 # Second phase: Execution phase.
 FROM alpine:latest


### PR DESCRIPTION
go-sqlite3 relies on CGO to work correctly.

![image](https://github.com/aaamoon/copilot-gpt4-service/assets/31370133/eda064e7-ed9d-4edb-a683-c9dac2383e31)

Another option is using a pure-go sqlite driver like https://pkg.go.dev/modernc.org/sqlite